### PR TITLE
Rewrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 obj
 .vs
 *.user
+/loadsln.ps1

--- a/Patches/AkSoundEngineControllerPatches.cs
+++ b/Patches/AkSoundEngineControllerPatches.cs
@@ -1,15 +1,29 @@
-﻿using HarmonyLib;
+﻿using BepInEx.Configuration;
+using HarmonyLib;
 
 namespace UCHQoLPatches.Patches;
 
 [HarmonyPatch(typeof(AkSoundEngineController))]
 public static class AkSoundEngineControllerPatches
 {
+    private static ConfigEntry<bool> EnableWhenUnfocused;
+
+    public static void InitializeConfig(ConfigFile config) {
+        EnableWhenUnfocused = config.Bind(
+            "QoL - Sounds", 
+            "Play Sounds When Unfocused", 
+            true, 
+            "Plays audio from game when the application is unfocused, e.g. when\nalt-tabbed or another application is selected."
+        );
+    }
+
     [HarmonyPrefix]
     [HarmonyPatch("OnApplicationFocus", MethodType.Normal)]
     public static bool OnApplicationFocus(bool focus)
     {
         // disable AkSoundEngineController.OnApplicationFocus to keep audio running when game is not focused
-        return false;
+        // return true = run the original method, return false = do not run the original method
+        // returns false when "EnableWhenUnfocused" is true, disabling the controller.
+        return !EnableWhenUnfocused.Value;
     }
 }

--- a/Patches/DeathDelayPatch.cs
+++ b/Patches/DeathDelayPatch.cs
@@ -1,0 +1,46 @@
+﻿using BepInEx.Configuration;
+using GameEvent;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace UCHQoLPatches.Patches {
+    // Some code based on https://github.com/cekco/UCH-BetterRespawn
+    // Optimized to not get called every phase change. Other mods may overwrite this value later.
+
+    public class DeathDelayPatch {
+
+        private static ConfigEntry<float> freeplayDeathTimer;
+        private static ConfigEntry<float> challengeDeathTimer;
+
+        public static void InitializeConfig(ConfigFile config) {
+            freeplayDeathTimer = config.Bind(
+                "QoL - Respawn",
+                "Freeplay Timer",
+                0.3f,
+                new ConfigDescription("Sets the time between dying and respawning in Freeplay mode.", new AcceptableValueRange<float>(0f,10f))
+            );
+            challengeDeathTimer = config.Bind(
+                "QoL - Respawn",
+                "Challenge Timer",
+                3f,
+                new ConfigDescription("Sets the time between dying and respawning in Challenge mode.\nValues over 5 seconds are banned as they give a postmortem advantage.", 
+                new AcceptableValueRange<float>(0f,5f))
+            );
+        }
+
+        [HarmonyPatch(typeof(GameControl), "NotifySetupStartDone")]
+        [HarmonyPostfix]
+        public static void PatchSetupStartFinish(ref Queue<GamePlayer> ___PlayerQueue) {
+            foreach (GamePlayer player in ___PlayerQueue) {
+                player.CharacterInstance.maxDeathDelay = GameSettings.GetInstance().GameMode switch
+                {
+                    GameState.GameMode.CHALLENGE => challengeDeathTimer.Value,
+                    GameState.GameMode.FREEPLAY => freeplayDeathTimer.Value,
+                    _ => player.CharacterPrefab.maxDeathDelay // default value, steals from the parent prefab used to construct.
+                };
+            }
+        }
+    }
+}

--- a/Patches/DeathDelayPatch.cs
+++ b/Patches/DeathDelayPatch.cs
@@ -7,9 +7,8 @@ using System.Text;
 
 namespace UCHQoLPatches.Patches {
     // Some code based on https://github.com/cekco/UCH-BetterRespawn
-    // Optimized to not get called every phase change. Other mods may overwrite this value later.
-
-    public class DeathDelayPatch {
+    [HarmonyPatch]
+    public static class DeathDelayPatch {
 
         private static ConfigEntry<float> freeplayDeathTimer;
         private static ConfigEntry<float> challengeDeathTimer;
@@ -41,6 +40,7 @@ namespace UCHQoLPatches.Patches {
                     _ => player.CharacterPrefab.maxDeathDelay // default value, steals from the parent prefab used to construct.
                 };
             }
+            UnityEngine.Debug.Log("abcdef | " + ___PlayerQueue.Count.ToString());
         }
     }
 }

--- a/Patches/DeathDelayPatch.cs
+++ b/Patches/DeathDelayPatch.cs
@@ -40,7 +40,6 @@ namespace UCHQoLPatches.Patches {
                     _ => player.CharacterPrefab.maxDeathDelay // default value, steals from the parent prefab used to construct.
                 };
             }
-            UnityEngine.Debug.Log("abcdef | " + ___PlayerQueue.Count.ToString());
         }
     }
 }

--- a/Patches/ToggleChatVisibility.cs
+++ b/Patches/ToggleChatVisibility.cs
@@ -1,0 +1,47 @@
+﻿using BepInEx.Configuration;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace UCHQoLPatches.Patches {
+    [HarmonyPatch(typeof(ChatDisplay))]
+    public static class HideChat {
+        private static ConfigEntry<KeyCode> ToggleVisibility;
+        private static ConfigEntry<float> MinimumHideLength;
+
+        private static float InvisibilityTimer;
+
+        public static void InitializeConfig(ConfigFile config) {
+            ToggleVisibility = config.Bind(
+                "ChatVisibility",
+                "ToggleWithKey",
+                KeyCode.Alpha0,
+                "Key to press to automatically open/close ChatDisplay"
+                );
+            MinimumHideLength = config.Bind(
+                "ChatVisibility",
+                "MinimumDelayBeforeVisible",
+                0.5f,
+                "The minimum amount of time between pressing the toggle key and the chat reappearing (in seconds).\nMessages sent in the next [hidelength] seconds will not reopen the chat, and you will not be able to open the chat for this amount of time."
+                );
+        }
+
+        [HarmonyPatch("Update")]
+        [HarmonyPostfix]
+        static void ToggleOnKeyBefore(ChatDisplay __instance, ref float ___VisibilityTimer) {
+            if (Input.GetKeyUp(ToggleVisibility.Value) && !__instance.currentChatInputField.inputField.isFocused) {
+                InvisibilityTimer = MinimumHideLength.Value;
+            }
+            if (InvisibilityTimer > 0f) {
+                __instance.currentChatInputField.CancelChatMessage();
+                __instance.currentChatInputField.gameObject.SetActive(false);
+                __instance.ChatMode = false;
+                ___VisibilityTimer = 0;
+                __instance.ChatCanvasGroup.alpha = 0f;
+            }
+            InvisibilityTimer -= Time.unscaledDeltaTime;
+        }
+    }
+}

--- a/Patches/ToggleChatVisibility.cs
+++ b/Patches/ToggleChatVisibility.cs
@@ -15,14 +15,14 @@ namespace UCHQoLPatches.Patches {
 
         public static void InitializeConfig(ConfigFile config) {
             ToggleVisibility = config.Bind(
-                "ChatVisibility",
-                "ToggleWithKey",
+                "QoL - Chat",
+                "Toggle With Key",
                 KeyCode.Alpha0,
                 "Key to press to automatically open/close ChatDisplay"
                 );
             MinimumHideLength = config.Bind(
-                "ChatVisibility",
-                "MinimumDelayBeforeVisible",
+                "QoL - Chat",
+                "Min Delay from Keypress",
                 0.5f,
                 "The minimum amount of time between pressing the toggle key and the chat reappearing (in seconds).\nMessages sent in the next [hidelength] seconds will not reopen the chat, and you will not be able to open the chat for this amount of time."
                 );

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -12,6 +12,7 @@ public class Plugin : BaseUnityPlugin
 {
     private void Awake()
     {
+        AkSoundEngineControllerPatches.InitializeConfig(Config);
         DeathDelayPatch.InitializeConfig(Config);
 
         new Harmony("uch.patch.qol.xxxprod.com").PatchAll();

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -14,6 +14,7 @@ public class Plugin : BaseUnityPlugin
     {
         AkSoundEngineControllerPatches.InitializeConfig(Config);
         DeathDelayPatch.InitializeConfig(Config);
+        HideChat.InitializeConfig(Config);
 
         new Harmony("uch.patch.qol.xxxprod.com").PatchAll();
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -2,46 +2,20 @@
 using BepInEx.Configuration;
 using GameEvent;
 using HarmonyLib;
+using UCHQoLPatches.Patches;
 using UnityEngine;
 
 namespace UCHQoLPatches;
 
 [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
-public class Plugin : BaseUnityPlugin, IGameEventListener
+public class Plugin : BaseUnityPlugin
 {
-    private ConfigEntry<float> _maxDeathDelay;
-
     private void Awake()
     {
+        DeathDelayPatch.InitializeConfig(Config);
+
         new Harmony("uch.patch.qol.xxxprod.com").PatchAll();
 
-        _maxDeathDelay = Config.Bind("FreePlay", "On Death Respawn Delay", 0.3f, "The delay in seconds until the character is respawned after death.");
-        _maxDeathDelay.SettingChanged += MaxDeathDelay_SettingChanged;
-
-        GameEventManager.ChangeListener<StartPhaseEvent>(this, true);
-
         Logger.LogInfo($"Plugin {PluginInfo.PLUGIN_GUID} is loaded!");
-    }
-
-    private void MaxDeathDelay_SettingChanged(object sender, System.EventArgs e)
-    {
-        UpdateMaxDeathDelay();
-    }
-
-    public void handleEvent(GameEvent.GameEvent e)
-    {
-        if (e is StartPhaseEvent)
-            UpdateMaxDeathDelay();
-    }
-
-    private void UpdateMaxDeathDelay()
-    {
-        Character[] characters = FindObjectsOfType<Character>();
-        foreach (Character character in characters)
-        {
-            character.maxDeathDelay = _maxDeathDelay.Value;
-        }
-
-        Debug.Log("Updated MaxDeathDelay on all characters.");
     }
 }

--- a/UCHQoLPatches.csproj
+++ b/UCHQoLPatches.csproj
@@ -6,7 +6,6 @@
 		<Description>UCH Mod that fixes some annoying things in Ultimate Chicken Horse</Description>
 		<Version>2.0.0</Version>
 		<LangVersion>latest</LangVersion>
-		<UCHDir>D:\Games\SteamLibrary\steamapps\common\Ultimate Chicken Horse</UCHDir>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -42,9 +41,13 @@
 			<HintPath>$(UCHDir)\UltimateChickenHorse_Data\Managed\AK.Wwise.Unity.MonoBehaviour.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="UnityEngine.UI">
+		  <HintPath>..\..\UltimateChickenHorse_Data\Managed\UnityEngine.UI.dll</HintPath>
+		  <Private>False</Private>
+		</Reference>
 	</ItemGroup>
 	
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="copy $(OutDir)* &quot;$(UCHDir)\BepInEx\plugins\&quot;" />
+		<Copy SourceFiles="$(OutDir)UCHQoLPatches.dll"  DestinationFolder="$(UCHDir)\BepInEx\plugins\$(MSBuildProjectName)\"/>
 	</Target>
 </Project>


### PR DESCRIPTION
I've rewritten a bunch of features to use other methods that will track less slowdowns.
Changes:
Features:
- Rewrote MaxDeathDelay to operate when a match *starts* and only on the players actively in the scene. More optimal than cekco's BetterRespawn, and the old method.
- Added Toggle option for unfocused audio (true by default)
- Added Toggle Chat Visibility - press `0` key (configurable) to remove chat from screen for 1 second (configurable) and hides until a new chat message is sent.

Nits:
- Moved DeathDelay to its own Patch class
- Made Patch classes static, for now.
- Changed tag name of configs. Feel free to change this.
